### PR TITLE
Don't automatically reconnect

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -19,7 +19,7 @@ $(document).ready(function () {
     $(".waiting-for-players").show();
 });
 
-var socket = io.connect(window.location.protocol + "//" + window.location.hostname + ":" + window.location.port);
+var socket = io.connect(window.location.protocol + "//" + window.location.hostname + ":" + window.location.port, {reconnection: false});
 
 let myUsername = "no username";
 let users = [];


### PR DESCRIPTION
Disabled automatic reconnection from client. This makes sure people who are not actually playing are not just automatically reconnecting without their knowledge.